### PR TITLE
[FIX] Corriger le bug lorsqu'on tente d'envoyer du texte par Bluetooth dans l'éditeur

### DIFF
--- a/bnote/apps/edt/editor_app.py
+++ b/bnote/apps/edt/editor_app.py
@@ -179,7 +179,7 @@ class EditorApp(EditorBaseApp):
         self._current_dialog = ui.UiInfoDialogBox(message=messages[activity], action=self._exec_cancel_dialog)
 
     def _exec_send_to(self):
-        if not self.__dialog_is_reading_file():
+        if not self._EditorBaseApp__dialog_is_reading_file():
             if not len(BnoteApp.bluetooth_devices):
                 self._current_dialog = ui.UiInfoDialogBox(message=_("not device connected"), action=self._exec_cancel_dialog)
                 return


### PR DESCRIPTION
## Problème
L'option d'envoi de texte par Bluetooth entraînait un crash lors de son utilisation

## Solution
Corriger l'appel à la fonction.
